### PR TITLE
fix: Update e2e tests to account for auto-loaded default podcast

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -12,8 +12,9 @@ test.describe('Podcast PWA', () => {
     await expect(page.getByRole('button', { name: 'Player' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Playlists' })).toBeVisible()
 
-    // Check for default view - updated to match actual text
-    await expect(page.getByText('No subscriptions yet. Add your first podcast!')).toBeVisible()
+    // Check that subscriptions section is visible (default podcast should auto-load)
+    await expect(page.getByRole('heading', { name: 'Subscriptions' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Add Podcast' })).toBeVisible()
   })
 
   test('should navigate between views', async ({ page }) => {
@@ -31,7 +32,9 @@ test.describe('Podcast PWA', () => {
 
     // Navigate back to Subscriptions
     await page.getByRole('button', { name: 'Subscriptions' }).click()
-    await expect(page.getByText('No subscriptions yet. Add your first podcast!')).toBeVisible()
+    // Check that we're back on subscriptions view
+    await expect(page.getByRole('heading', { name: 'Subscriptions' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Add Podcast' })).toBeVisible()
   })
 
   test('should be a PWA', async ({ page }) => {


### PR DESCRIPTION
## Summary
This PR fixes the failing e2e tests by updating test expectations to account for the auto-initialization feature in SubscriptionsView.

## Problem
The SubscriptionsView component automatically loads a default podcast (https://cmwen.github.io/podcasts/feed.xml) when no subscriptions exist. The e2e tests were expecting to see the 'No subscriptions yet. Add your first podcast!' message, but this text never appears (or disappears very quickly) because the default podcast is loaded automatically.

## Solution
Updated the e2e tests to check for the presence of elements that are always visible on the Subscriptions view:
- The 'Subscriptions' heading
- The 'Add Podcast' button

These elements are visible regardless of whether subscriptions exist or not, making the tests more reliable.

## Test Results
✅ All 25 e2e tests passing across all browsers:
- Chromium (5/5 tests)
- Firefox (5/5 tests)
- Webkit (5/5 tests)
- Mobile Chrome (5/5 tests)
- Mobile Safari (5/5 tests)

## Changes
- Updated test: 'should load the app and display navigation'
- Updated test: 'should navigate between views'